### PR TITLE
[posix-shim] Bug Fix: move libc initialization before it is used

### DIFF
--- a/src/interpose.c
+++ b/src/interpose.c
@@ -24,10 +24,10 @@
         type ret = -1;                                                                                                 \
         static bool reentrant = false;                                                                                 \
                                                                                                                        \
+        init();                                                                                                        \
+                                                                                                                       \
         if ((!initialized) || (reentrant))                                                                             \
             return (fn_libc(__VA_ARGS__));                                                                             \
-                                                                                                                       \
-        init();                                                                                                        \
                                                                                                                        \
         int last_errno = errno;                                                                                        \
                                                                                                                        \


### PR DESCRIPTION
A `read(*)` may be invoke before any socket is created, which may cause `libc_read` be called before it is properly initialized, moving `init` before those potential calls.